### PR TITLE
has-transformed-position: bug fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/).
 
 ## Unreleased
 
+### Fixed
+- `has-transformed-position` accepts null type for native units (like `has-position`)
+- fixed bug in `has-transformed-position` where `get_native_destination` was not a message
+
 ## [2022.7.0]
 
 ### Added

--- a/yaq_traits/has-transformed-position.toml
+++ b/yaq_traits/has-transformed-position.toml
@@ -66,7 +66,7 @@ response = ["null", "string"]
 
 [messages.get_native_destination]
 doc = "Get the destination in native coordinates."
-response = "double
+response = "double"
 
 [properties]
 

--- a/yaq_traits/has-transformed-position.toml
+++ b/yaq_traits/has-transformed-position.toml
@@ -62,8 +62,11 @@ response = {"type"="array", "items"="double"}
 
 [messages.get_native_units]
 doc = "Get the units of native coordinates."
-response = "string"
+response = ["null", "string"]
 
+[messages.get_native_destination]
+doc = "Get the destination in native coordinates."
+response = "double
 
 [properties]
 


### PR DESCRIPTION
1) get_native_destination is a getter, but we had no such message declared
2) for native units, allow default (null) type